### PR TITLE
Make Ollama client use configurable timeout

### DIFF
--- a/cmd/document.go
+++ b/cmd/document.go
@@ -65,7 +65,7 @@ func runDocument(cmd *cobra.Command, args []string) error {
     spinner.UpdateText("Generating documentation...")
     
     // Initialize Ollama client
-    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature)
+    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature, cfg.Ollama.Timeout)
     
     // Build prompt
     prompt := buildDocumentPrompt(language, documentStyle, originalCode)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -49,7 +49,7 @@ func runNew(cmd *cobra.Command, args []string) error {
     }
     
     // Initialize Ollama client
-    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature)
+    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature, cfg.Ollama.Timeout)
     
     // Prepare context
     var context string

--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -76,7 +76,7 @@ func runRefactor(cmd *cobra.Command, args []string) error {
     spinner.UpdateText("Refactoring code...")
     
     // Initialize Ollama client
-    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature)
+    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature, cfg.Ollama.Timeout)
     
     // Detect language
     language := utils.DetectLanguage(fileName)

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -59,7 +59,7 @@ func runReview(cmd *cobra.Command, args []string) error {
     language := utils.DetectLanguage(fileName)
     
     // Initialize Ollama client
-    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature)
+    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature, cfg.Ollama.Timeout)
     
     // Build prompt
     prompt := buildReviewPrompt(language, code, reviewTask)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -69,7 +69,7 @@ func runTest(cmd *cobra.Command, args []string) error {
     spinner.UpdateText("Generating unit tests...")
     
     // Initialize Ollama client
-    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature)
+    client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature, cfg.Ollama.Timeout)
     
     // Build prompt
     prompt := buildTestPrompt(language, testFramework, sourceCode, fileName)

--- a/internal/ollama/client.go
+++ b/internal/ollama/client.go
@@ -42,13 +42,16 @@ type GenerateResponse struct {
 }
 
 // NewClient creates a new Ollama API client
-func NewClient(baseURL, model string, temperature float32) *Client {
+func NewClient(baseURL, model string, temperature float32, timeout time.Duration) *Client {
+    if timeout == 0 {
+        timeout = 120 * time.Second
+    }
     return &Client{
         baseURL:     strings.TrimRight(baseURL, "/"),
         model:       model,
         temperature: temperature,
         httpClient: &http.Client{
-            Timeout: 120 * time.Second,
+            Timeout: timeout,
         },
     }
 }


### PR DESCRIPTION
## Summary
- add `timeout` parameter to `ollama.NewClient`
- wire timeout from config into each command

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go fmt ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68874ca158d88321976c676f97fe89be