### PR TITLE
Handle spinner errors in new and test commands

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -45,7 +45,8 @@ func runNew(cmd *cobra.Command, args []string) error {
     spinner, err := pterm.DefaultSpinner.Start("Generating code...")
     if err != nil {
         // Continue without spinner
-        pterm.Warning.Println("Failed to start spinner")
+        pterm.Warning.Printf("Failed to start spinner: %v\n", err)
+        spinner = nil
     }
     
     // Initialize Ollama client
@@ -56,7 +57,11 @@ func runNew(cmd *cobra.Command, args []string) error {
     if newContextFile != "" {
         contextContent, err := utils.ReadFile(newContextFile)
         if err != nil {
-            spinner.Fail(fmt.Sprintf("Failed to read context file: %v", err))
+            if spinner != nil {
+                spinner.Fail(fmt.Sprintf("Failed to read context file: %v", err))
+            } else {
+                pterm.Warning.Printf("Failed to read context file: %v\n", err)
+            }
             return err
         }
         context = fmt.Sprintf("Reference file (%s):\n%s\n\n", newContextFile, contextContent)
@@ -71,11 +76,19 @@ func runNew(cmd *cobra.Command, args []string) error {
     // Generate code
     generatedCode, err := client.Generate(cmd.Context(), prompt)
     if err != nil {
-        spinner.Fail(fmt.Sprintf("Failed to generate code: %v", err))
+        if spinner != nil {
+            spinner.Fail(fmt.Sprintf("Failed to generate code: %v", err))
+        } else {
+            pterm.Warning.Printf("Failed to generate code: %v\n", err)
+        }
         return err
     }
-    
-    spinner.Success("Code generated successfully!")
+
+    if spinner != nil {
+        spinner.Success("Code generated successfully!")
+    } else {
+        pterm.Info.Println("Code generated successfully!")
+    }
     
     // Display generated code
     pterm.DefaultHeader.Println("Generated Code")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -45,13 +45,18 @@ func runTest(cmd *cobra.Command, args []string) error {
     spinner, err := pterm.DefaultSpinner.Start("Analyzing code for test generation...")
     if err != nil {
         // Continue without spinner
-        pterm.Warning.Println("Failed to start spinner")
+        pterm.Warning.Printf("Failed to start spinner: %v\n", err)
+        spinner = nil
     }
     
     // Read source file
     sourceCode, err := utils.ReadFile(fileName)
     if err != nil {
-        spinner.Fail(fmt.Sprintf("Failed to read file: %v", err))
+        if spinner != nil {
+            spinner.Fail(fmt.Sprintf("Failed to read file: %v", err))
+        } else {
+            pterm.Warning.Printf("Failed to read file: %v\n", err)
+        }
         return err
     }
     
@@ -66,7 +71,11 @@ func runTest(cmd *cobra.Command, args []string) error {
     // Generate test file name
     testFileName := generateTestFileName(fileName, language)
     
-    spinner.UpdateText("Generating unit tests...")
+    if spinner != nil {
+        spinner.UpdateText("Generating unit tests...")
+    } else {
+        pterm.Info.Println("Generating unit tests...")
+    }
     
     // Initialize Ollama client
     client := ollama.NewClient(cfg.Ollama.APIURL, cfg.Ollama.Model, cfg.Ollama.Temperature)
@@ -77,11 +86,19 @@ func runTest(cmd *cobra.Command, args []string) error {
     // Generate tests
     testCode, err := client.Generate(cmd.Context(), prompt)
     if err != nil {
-        spinner.Fail(fmt.Sprintf("Failed to generate tests: %v", err))
+        if spinner != nil {
+            spinner.Fail(fmt.Sprintf("Failed to generate tests: %v", err))
+        } else {
+            pterm.Warning.Printf("Failed to generate tests: %v\n", err)
+        }
         return err
     }
-    
-    spinner.Success("Tests generated successfully!")
+
+    if spinner != nil {
+        spinner.Success("Tests generated successfully!")
+    } else {
+        pterm.Info.Println("Tests generated successfully!")
+    }
     
     // Display generated tests
     pterm.DefaultHeader.Println("Generated Tests")


### PR DESCRIPTION
## Summary
- check for Start errors in `new` and `test` commands
- guard spinner actions when spinner is not available

## Testing
- `go test ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68874ca1ee8c8321bbf1b8d88d87a651