### PR TITLE
Add Node and Electron types to desktop tsconfigs

### DIFF
--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "types": ["node", "electron"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true

--- a/desktop/tsconfig.main.json
+++ b/desktop/tsconfig.main.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
+    "types": ["node", "electron"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true


### PR DESCRIPTION
## Summary
- update `desktop/tsconfig.json` and `desktop/tsconfig.main.json` to include Node and Electron types

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'electron' and 'node')*

------
https://chatgpt.com/codex/tasks/task_e_688750eaeaa083219a305f73e77591ef