### PR TITLE
Add file-type styles to FileExplorer

### DIFF
--- a/desktop/src/components/FileExplorer/FileExplorer.css
+++ b/desktop/src/components/FileExplorer/FileExplorer.css
@@ -89,6 +89,42 @@
     color: var(--accent-color);
 }
 
+/* File extension colors */
+.file-item.ext-js,
+.file-item.ext-js .file-icon {
+    color: var(--color-js);
+}
+
+.file-item.ext-ts,
+.file-item.ext-ts .file-icon {
+    color: var(--color-ts);
+}
+
+.file-item.ext-py,
+.file-item.ext-py .file-icon {
+    color: var(--color-py);
+}
+
+.file-item.ext-go,
+.file-item.ext-go .file-icon {
+    color: var(--color-go);
+}
+
+.file-item.ext-md,
+.file-item.ext-md .file-icon {
+    color: var(--color-md);
+}
+
+.file-item.ext-json,
+.file-item.ext-json .file-icon {
+    color: var(--color-json);
+}
+
+.file-item.ext-image,
+.file-item.ext-image .file-icon {
+    color: var(--color-image);
+}
+
 .file-name {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -168,6 +204,13 @@
     --accent-color: #ffffff;
     --scrollbar-thumb: #cccccc;
     --scrollbar-thumb-hover: #999999;
+    --color-js: #f1e05a;
+    --color-ts: #3178c6;
+    --color-py: #3572a5;
+    --color-go: #00add8;
+    --color-md: #083fa1;
+    --color-json: #cbcb41;
+    --color-image: #a074c4;
 }
 
 /* Dark theme */
@@ -182,4 +225,11 @@
     --accent-color: #ffffff;
     --scrollbar-thumb: #424242;
     --scrollbar-thumb-hover: #525252;
+    --color-js: #f1e05a;
+    --color-ts: #3178c6;
+    --color-py: #3572a5;
+    --color-go: #00add8;
+    --color-md: #83a1ff;
+    --color-json: #dcdcaa;
+    --color-image: #c586c0;
 }

--- a/desktop/src/components/FileExplorer/index.tsx
+++ b/desktop/src/components/FileExplorer/index.tsx
@@ -203,15 +203,45 @@ const FileExplorer: React.FC<FileExplorerProps> = ({ onFileSelect, rootPath = '.
     };
 
     // Dosya ağacı render
+    const extensionClassMap: Record<string, string> = {
+        js: 'ext-js',
+        jsx: 'ext-js',
+        ts: 'ext-ts',
+        tsx: 'ext-ts',
+        py: 'ext-py',
+        go: 'ext-go',
+        java: 'ext-java',
+        c: 'ext-c',
+        cpp: 'ext-cpp',
+        php: 'ext-php',
+        md: 'ext-md',
+        txt: 'ext-txt',
+        json: 'ext-json',
+        yml: 'ext-yaml',
+        yaml: 'ext-yaml',
+        jpg: 'ext-image',
+        jpeg: 'ext-image',
+        png: 'ext-image',
+        gif: 'ext-image',
+        svg: 'ext-image',
+        bmp: 'ext-image',
+    };
+
+    const getExtensionClass = (fileName: string) => {
+        const ext = fileName.split('.').pop()?.toLowerCase() || '';
+        return extensionClassMap[ext] || '';
+    };
+
     const renderTree = (nodes: FileNode[], level = 0) => {
         return nodes.map((node) => {
             const isExpanded = expandedFolders.has(node.path);
             const isSelected = selectedFile === node.path;
+            const extClass = node.type === 'file' ? getExtensionClass(node.name) : '';
 
             return (
                 <div key={node.path}>
                     <div
-                        className={`file-item ${isSelected ? 'selected' : ''}`}
+                        className={`file-item ${extClass} ${isSelected ? 'selected' : ''}`}
                         style={{ paddingLeft: `${level * 20 + 10}px` }}
                         onClick={() => handleFileClick(node)}
                         onContextMenu={(e) => handleContextMenu(e, node.path)}


### PR DESCRIPTION
## Summary
- apply file type css classes in FileExplorer
- add extension color mapping and variables

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'electron')*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688761ecb8708321ac1a9299a110c4e1